### PR TITLE
Adjust comment about installing ojdbc to the version 7 and 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ The Integration Tests require some external configurations:
     
     1. You can follow the steps explained in [this article](http://docs.oracle.com/middleware/1213/core/MAVEN/config_maven_repo.htm#MAVEN9010) to set up the Oracle Maven Repository.
 
-    2. You can also download the Oracle JDBC Driver (ojdbc6.jar and ojdbc7_g.jar), which is not available in the Maven Central Repository.
-    and install the ojdbc6.jar and ojdbc7_g.jar on your local Maven repository using the following command:
+    2. You can also download the Oracle JDBC Driver (ojdbc7_g.jar and ojdbc8.jar), which is not available in the Maven Central Repository.
+    and install the ojdbc7_g.jar and ojdbc8.jar on your local Maven repository using the following command:
 
-            $ mvn install:install-file -Dfile=ojdbc6.jar -DgroupId=com.oracle.jdbc -DartifactId=ojdbc6 -Dversion=11.2.0.4 -Dpackaging=jar
             $ mvn install:install-file -Dfile=ojdbc7_g.jar -DgroupId=com.oracle.jdbc -DartifactId=ojdbc7 -Dversion=12.1.0.2 -Dpackaging=jar 
+            $ mvn install:install-file -Dfile=ojdbc8.jar -DgroupId=com.oracle.jdbc -DartifactId=ojdbc8 -Dversion=12.2.0.1 -Dpackaging=jar
 
 - MySQL
 


### PR DESCRIPTION
Hi Vlad

I spent some time on getting your current updates work with eclipse. I decided to restart with my eclipse branch (renaming the doInXXX return values instead of the void ones - as they occur less frequently).

As a side effect I am suggesting some changes to the README, placed as separate pull requests (with some dedicated commits, so you could easily cherry-pick if necessary).

This first one updates the instructions for the ojdbc drivers.

Would you prefer referencing `ojdbc8_g.jar` over `ojdbc8.jar`? Let me know and I'll adjust to that.

Thanks and cheers
Urs