### PR TITLE
Improve performance of JsonTypeDescriptor.areEqual

### DIFF
--- a/core/src/main/java/com/vladmihalcea/book/hpjp/hibernate/type/json/JsonTypeDescriptor.java
+++ b/core/src/main/java/com/vladmihalcea/book/hpjp/hibernate/type/json/JsonTypeDescriptor.java
@@ -38,6 +38,9 @@ public class JsonTypeDescriptor
         if ( one == null || another == null ) {
             return false;
         }
+        if ( one instanceof String && another instanceof String ) {
+            return one.equals(another);
+        }
         return JacksonUtil.toJsonNode(JacksonUtil.toString(one)).equals(
                 JacksonUtil.toJsonNode(JacksonUtil.toString(another)));
     }


### PR DESCRIPTION
Hi,

recently I found that `JsonTypeDescriptor.areEqual()` checks can be optimized if the objects are already of type String. What do you think of the proposed change?

Cheers,
Christoph 