### PR TITLE
Remove properties-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,26 +369,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <!--<property>
-                                    <name>hibernate.bytecode.provider</name>
-                                    <value>bytebuddy</value>
-                                </property>-->
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>


### PR DESCRIPTION
The properties-maven-plugin doesn't do anything and breaks
with Maven 3.5.3 because no version is specified