### PR TITLE
Fail merge

### DIFF
--- a/core/src/test/java/com/vladmihalcea/book/hpjp/hibernate/association/BidirectionalOneToManyMergeTest.java
+++ b/core/src/test/java/com/vladmihalcea/book/hpjp/hibernate/association/BidirectionalOneToManyMergeTest.java
@@ -151,6 +151,16 @@ public class BidirectionalOneToManyMergeTest extends AbstractTest {
         verifyResults();
     }
 
+    @Test
+    public void testFailMerge() {
+        doInJPA(entityManager -> {
+            Post post = entityManager.find(Post.class, 1L);
+            post.addComment(new PostComment("This post rocks!"));
+            post.getComments().isEmpty(); // this fails
+            entityManager.merge(post);
+        });
+    }
+
     public List<PostComment> fetchPostComments(Long postId) {
         return doInJPA(entityManager -> {
             return entityManager.createQuery(


### PR DESCRIPTION
This test fails because an org.hibernate.TransientObjectException is
thrown when calling post.getComments().isEmpty() with a merge operation.

A couple of things to mention:

* Although calling isEmpty() is useless here, it serves as a testing
  propose. Deleting this call avoids the exception.
* Retrieving the post along with its comments using a "LEFT JOIN FETCH"
  query not only avoids the exception but also is better in terms of
  performance.
* Calling entityManager.persist(post) instead of
  entityManager.merge(post) also avoids the exception. In fact, both
  calls are redundant since the post is being managed by the current
  running Persistence Context.