### PR TITLE
Join fetching OneToMany association using a non-Primary Key

### DIFF
--- a/core/src/test/java/com/vladmihalcea/book/hpjp/hibernate/association/OneToManyJoinColumnNonPKTest.java
+++ b/core/src/test/java/com/vladmihalcea/book/hpjp/hibernate/association/OneToManyJoinColumnNonPKTest.java
@@ -46,20 +46,10 @@ public class OneToManyJoinColumnNonPKTest extends AbstractTest {
             Customer customer = entityManager.createQuery(
                 "select c " +
                 "from Customer c " +
-                "inner join fetch c.orders o " +
+                "join fetch c.orders o " +
                 "where c.msisdn = :msisdn", Customer.class)
             .setParameter( "msisdn", "+306972333666" )
             .getSingleResult();
-
-            //assertEquals(
-            //    "amazon.co.uk",
-            //    publication.getPublisher()
-            //);
-			//
-            //assertEquals(
-            //    "High-Performance Java Persistence",
-            //    publication.getBook().getTitle()
-            //);
         });
     }
 

--- a/core/src/test/java/com/vladmihalcea/book/hpjp/hibernate/association/OneToManyJoinColumnNonPKTest.java
+++ b/core/src/test/java/com/vladmihalcea/book/hpjp/hibernate/association/OneToManyJoinColumnNonPKTest.java
@@ -1,0 +1,163 @@
+package com.vladmihalcea.book.hpjp.hibernate.association;
+
+import com.vladmihalcea.book.hpjp.util.AbstractTest;
+import org.hibernate.annotations.NaturalId;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * @author Kyriakos Mandalas
+ */
+public class OneToManyJoinColumnNonPKTest extends AbstractTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[] {
+            Customer.class,
+            Order.class,
+        };
+    }
+
+    @Test
+    public void test() {
+        doInJPA(entityManager -> {
+        	Customer customer = new Customer();
+        	customer.setCode("978-9730228236");
+        	customer.setMsisdn("+306972333666");
+        	customer.setStatus("ACTIVE");
+        	entityManager.persist(customer);
+
+        	Order pendingOrder = new Order();
+			pendingOrder.setOrderNumber(73647367);
+			pendingOrder.setStatus("PENDING");
+			pendingOrder.setCustomer(customer);
+        	entityManager.persist(pendingOrder);
+
+			Order completedOrder = new Order();
+			completedOrder.setOrderNumber(84758478);
+			completedOrder.setStatus("COMPLETED");
+			completedOrder.setCustomer(customer);
+			entityManager.persist(completedOrder);
+        });
+        doInJPA(entityManager -> {
+            Customer customer = entityManager.createQuery(
+                "select c " +
+                "from Customer c " +
+                "inner join fetch c.orders o " +
+                "where c.msisdn = :msisdn", Customer.class)
+            .setParameter( "msisdn", "+306972333666" )
+            .getSingleResult();
+
+            //assertEquals(
+            //    "amazon.co.uk",
+            //    publication.getPublisher()
+            //);
+			//
+            //assertEquals(
+            //    "High-Performance Java Persistence",
+            //    publication.getBook().getTitle()
+            //);
+        });
+    }
+
+	@Entity(name = "Customer")
+	@Table(name = "customer")
+	public static class Customer implements Serializable {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Column(unique = true)
+		private String msisdn;
+
+		@Column(name = "status")
+		private String status;
+
+		@Column(name = "code", unique = true, nullable = false)
+		@NaturalId
+		private String code;
+
+		@OneToMany(mappedBy = "customer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		private Set<Order> orders;
+
+		public String getMsisdn() {
+			return msisdn;
+		}
+
+		public void setMsisdn(String msisdn) {
+			this.msisdn = msisdn;
+		}
+
+		public String getStatus() {
+			return status;
+		}
+
+		public void setStatus(String status) {
+			this.status = status;
+		}
+
+		public String getCode() {
+			return code;
+		}
+
+		public void setCode(String code) {
+			this.code = code;
+		}
+
+		public Set<Order> getOrders() {
+			return orders;
+		}
+
+		public void setOrders(Set<Order> orders) {
+			this.orders = orders;
+		}
+	}
+
+	@Entity(name = "Order")
+	@Table(name = "orders")
+	public static class Order {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Column(name = "order_no", unique = true)
+		private Integer orderNumber;
+
+		@Column(name = "status")
+		private String status;
+
+		@ManyToOne(fetch = FetchType.LAZY, optional = false)
+		@JoinColumn(name = "customer_code", referencedColumnName = "code", nullable = false)
+		private Customer customer;
+
+		public Integer getOrderNumber() {
+			return orderNumber;
+		}
+
+		public void setOrderNumber(Integer orderNumber) {
+			this.orderNumber = orderNumber;
+		}
+
+		public String getStatus() {
+			return status;
+		}
+
+		public void setStatus(String status) {
+			this.status = status;
+		}
+
+		public Customer getCustomer() {
+			return customer;
+		}
+
+		public void setCustomer(Customer customer) {
+			this.customer = customer;
+		}
+	}
+
+}


### PR DESCRIPTION
This is to reproduce the issue asked here: https://stackoverflow.com/questions/62281835/hibernate-doing-multiple-queries-when-join-fetch-is-used-with-reference-column-o

We see 2 queries being generated: 

1. 2020-06-09 22:33:01,517 DEBUG [Alice]: n.t.d.l.l.SLF4JQueryLoggingListener - Name:DATA_SOURCE_PROXY, Connection:5, Time:0, Success:True, Type:Prepared, Batch:False, QuerySize:1, BatchSize:0, Query:["select onetomanyj0_.id as id1_0_0_, orders1_.id as id1_1_1_, onetomanyj0_.code as code2_0_0_, onetomanyj0_.msisdn as msisdn3_0_0_, onetomanyj0_.status as status4_0_0_, orders1_.customer_code as customer4_1_1_, orders1_.order_no as order_no2_1_1_, orders1_.status as status3_1_1_, orders1_.customer_code as customer4_1_0__, orders1_.id as id1_1_0__ from customer onetomanyj0_ inner join orders orders1_ on onetomanyj0_.code=orders1_.customer_code where onetomanyj0_.msisdn=?"], Params:[(+306972333666)]

2. 2020-06-09 22:33:01,529 DEBUG [Alice]: n.t.d.l.l.SLF4JQueryLoggingListener - Name:DATA_SOURCE_PROXY, Connection:5, Time:0, Success:True, Type:Prepared, Batch:False, QuerySize:1, BatchSize:0, Query:["select onetomanyj0_.id as id1_0_0_, onetomanyj0_.code as code2_0_0_, onetomanyj0_.msisdn as msisdn3_0_0_, onetomanyj0_.status as status4_0_0_ from customer onetomanyj0_ where onetomanyj0_.code=?"], Params:[(978-9730228236)]
