### PR TITLE
Fix MySQL command to set password for user, the existing command is not working on MySQL v8 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The Integration Tests require some external configurations:
     ````
     CREATE USER 'mysql'@'localhost';
     
-    SET PASSWORD for 'mysql'@'localhost' = PASSWORD('admin');
+    SET PASSWORD for 'mysql'@'localhost'='admin';
     
     GRANT ALL PRIVILEGES ON high_performance_java_persistence.* TO 'mysql'@'localhost';
     


### PR DESCRIPTION
Dear Vlad,

I'm taking your High-Performance Java Persistence course. While setting up the workspace with MySQL, I encountered an error in one of the MySQL commands. Raising this Pull Request to get it corrected. 

Regards,
Devesh Mankar 