### PR TITLE
fix: maven jvm config locale defaults for the non-english oses

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Duser.country=US -Duser.language=en


### PR DESCRIPTION
fix for #86:  Set default JVM language as English for maven on non-english operating systems. #86 