### PR TITLE
Allow Batch insert when using Hibernate > 6.1 and MySQL

### DIFF
--- a/core/src/test/java/com/vladmihalcea/hpjp/spring/stateless/config/SpringStatelessSessionBatchingConfiguration.java
+++ b/core/src/test/java/com/vladmihalcea/hpjp/spring/stateless/config/SpringStatelessSessionBatchingConfiguration.java
@@ -1,5 +1,6 @@
 package com.vladmihalcea.hpjp.spring.stateless.config;
 
+import com.vladmihalcea.hpjp.spring.stateless.hibernate.CustomMutationExecutorService;
 import com.vladmihalcea.hpjp.util.DataSourceProxyType;
 import com.vladmihalcea.hpjp.util.logging.InlineQueryLogEntryCreator;
 import com.vladmihalcea.hpjp.util.providers.DataSourceProvider;
@@ -55,6 +56,8 @@ import java.util.Properties;
 public class SpringStatelessSessionBatchingConfiguration {
 
     public static final String DATA_SOURCE_PROXY_NAME = DataSourceProxyType.DATA_SOURCE_PROXY.name();
+    public static final String EXECUTOR_KEY = "hibernate.jdbc.mutation.executor";
+    public static final String EXECUTOR_NAME = CustomMutationExecutorService.class.getName();
 
     private int maxConnections = 64;
 
@@ -166,6 +169,8 @@ public class SpringStatelessSessionBatchingConfiguration {
             AvailableSettings.ORDER_UPDATES,
             Boolean.TRUE.toString()
         );
+        //adding custom executor
+        properties.setProperty(EXECUTOR_KEY, EXECUTOR_NAME);
         return properties;
     }
 

--- a/core/src/test/java/com/vladmihalcea/hpjp/spring/stateless/domain/NoOpGenerator.java
+++ b/core/src/test/java/com/vladmihalcea/hpjp/spring/stateless/domain/NoOpGenerator.java
@@ -1,16 +1,29 @@
 package com.vladmihalcea.hpjp.spring.stateless.domain;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.id.IdentifierGenerator;
-import org.hibernate.id.factory.spi.StandardGenerator;
+import org.hibernate.generator.BeforeExecutionGenerator;
+import org.hibernate.generator.EventType;
+import org.hibernate.id.IdentityGenerator;
 
 /**
  * @author Vlad Mihalcea
  */
-public class NoOpGenerator implements IdentifierGenerator, StandardGenerator {
+public class NoOpGenerator extends IdentityGenerator
+        implements BeforeExecutionGenerator {
+    @Override
+    public boolean generatedOnExecution(Object entity, SharedSessionContractImplementor session) {
+        //necessary so StatelessSessionImpl will try to generate the id before insert, otherwise it throws an error because batch insert doesn't return an id
+        return false;
+    }
 
     @Override
-    public Object generate(SharedSessionContractImplementor session, Object obj) {
+    public Object generate(
+            SharedSessionContractImplementor session, Object owner, Object currentValue, EventType eventType) {
         return null;
+    }
+
+    @Override
+    public boolean generatedOnExecution() {
+        return true;
     }
 }

--- a/core/src/test/java/com/vladmihalcea/hpjp/spring/stateless/hibernate/CustomMutationExecutorService.java
+++ b/core/src/test/java/com/vladmihalcea/hpjp/spring/stateless/hibernate/CustomMutationExecutorService.java
@@ -1,0 +1,58 @@
+package com.vladmihalcea.hpjp.spring.stateless.hibernate;
+
+import com.vladmihalcea.hpjp.spring.stateless.domain.BatchInsertPost;
+import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
+import org.hibernate.engine.jdbc.batch.spi.BatchKey;
+import org.hibernate.engine.jdbc.mutation.MutationExecutor;
+import org.hibernate.engine.jdbc.mutation.internal.MutationExecutorServiceInitiator;
+import org.hibernate.engine.jdbc.mutation.internal.MutationExecutorSingleBatched;
+import org.hibernate.engine.jdbc.mutation.internal.StandardMutationExecutorService;
+import org.hibernate.engine.jdbc.mutation.spi.BatchKeyAccess;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.sql.model.*;
+
+/**
+ * Custom MutationExecutorService implementation that allows batch insertion for Identity Generator
+ *
+ * @author Fernando Silva
+ * @see MutationExecutorServiceInitiator
+ */
+public class CustomMutationExecutorService extends StandardMutationExecutorService {
+    //private field in StandardMutationExecutorService
+    private final int globalBatchSize;
+
+    //default constructor used by Hibernate
+    public CustomMutationExecutorService() {
+        super(8);
+        this.globalBatchSize = 8;
+    }
+
+    @Override
+    public MutationExecutor createExecutor(
+            BatchKeyAccess batchKeySupplier,
+            MutationOperationGroup operationGroup,
+            SharedSessionContractImplementor session) {
+
+        int batchSizeToUse = session.getJdbcCoordinator().getJdbcSessionOwner().getJdbcBatchSize() == null ? globalBatchSize : session.getJdbcCoordinator().getJdbcSessionOwner().getJdbcBatchSize();
+
+        //only uses batch for BatachInsert
+        if (isSingleInsertOperationForBatchInsert(operationGroup)) {
+            PreparableMutationOperation jdbcOperation = (PreparableMutationOperation) operationGroup.getSingleOperation();
+            //batch key is not set in batchKeySupplier because it's a generated id
+            BatchKey batchKey = new BasicBatchKey(BatchInsertPost.class + "#INSERT", null);
+            return new MutationExecutorSingleBatched(jdbcOperation, batchKey, batchSizeToUse, session);
+        }
+
+        return super.createExecutor(batchKeySupplier, operationGroup, session);
+    }
+
+    private boolean isSingleInsertOperationForBatchInsert(MutationOperationGroup operationGroup) {
+        if (operationGroup.getNumberOfOperations() != 1) {
+            return false;
+        }
+        MutationType mutationType = operationGroup.getMutationType();
+        EntityMutationOperationGroup entityMutationOperationGroup = operationGroup.asEntityMutationOperationGroup();
+        return entityMutationOperationGroup != null && mutationType == MutationType.INSERT && entityMutationOperationGroup.getMutationTarget().getTargetPart().getJavaType().getJavaTypeClass().isAssignableFrom(BatchInsertPost.class);
+    }
+
+}


### PR DESCRIPTION
Starting in Hibernate 6.2 the logic for ID generator changed which broke the current workaround for MySQL batch insert. See https://hibernate.atlassian.net/browse/HHH-16692